### PR TITLE
0.2.0 - User state hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### v0.2.0 2023-11-09
+
+#### Changes
+- [Enabled user-state hooks](https://tailor-cms.github.io/xt/server-package.html#user-state-hooks)
+
+#### Migration instructions
+- Bump tce-boot to `0.2.0`
+- [Add the display context to the manifest interface](https://github.com/tailor-cms/tce-template/pull/16/files#diff-363caee1e8047788dee5a0a3feca5d40a88c160dd36abadb550e8577ae0d3244R38)
+- [Add the example display context to the manifest](https://github.com/tailor-cms/tce-template/pull/16/files#diff-c248ce0c077134efe1982e29743139541a2d28d6ace0e3f6e5a50cf09f1beaafR29)
+- [Add beforeDisplay and onUserInteraction hooks](https://github.com/tailor-cms/tce-template/pull/16/files#diff-8e6dfbbfb522575fe7c568c2de518bf9de351de83c9dbb48eaa865cd54450eb3R40)
+- [Define userState prop on the Display component](https://github.com/tailor-cms/tce-template/pull/16/files#diff-cfb5d05096f2f57087b355fa04ea9ac63033d96b4f1100db0991c69baa4aebc7R12)
+
+-[For more details see 0.2.0 PR](https://github.com/tailor-cms/tce-template/pull/16/files)
+
+---
+
 ### v0.1.0 2023-10-18
 
 #### Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tailor-cms/tce-template",
   "description": "Content element template",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "ExtensionEngine <info@extensionengine.com>",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@playwright/test": "^1.37.1",
     "@tailor-cms/eslint-config": "0.0.2",
-    "@tailor-cms/tce-boot": "0.2.0-beta.7",
+    "@tailor-cms/tce-boot": "0.2.0",
     "@types/node": "^20.5.7",
     "prettier": "^2.7.1",
     "typescript": "^5.1.6",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@playwright/test": "^1.37.1",
     "@tailor-cms/eslint-config": "0.0.2",
-    "@tailor-cms/tce-boot": "0.1.1",
+    "@tailor-cms/tce-boot": "0.2.0-beta.7",
     "@types/node": "^20.5.7",
     "prettier": "^2.7.1",
     "typescript": "^5.1.6",

--- a/packages/display/src/components/Display.vue
+++ b/packages/display/src/components/Display.vue
@@ -1,13 +1,18 @@
 <template>
   <div class="tce-root">
     <p>This is the Display version of the content element {{ id }}</p>
+    <v-btn class="my-6" @click="submit">Update user state</v-btn>
+    <div>User state: {{ userState }}</div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ElementData } from 'tce-manifest';
 
-defineProps<{ id: number; data: ElementData }>();
+const props = defineProps<{ id: number; data: ElementData; userState: any }>();
+const emit = defineEmits(['interaction']);
+
+const submit = () => emit('interaction', { id: props.id });
 </script>
 
 <style scoped>

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -26,6 +26,10 @@ const ui = {
   forceFullWidth: true,
 };
 
+export const mocks = {
+  displayContexts: [{ name: 'Test', data: { exampleValue: 'test' } }],
+};
+
 const manifest: ElementManifest = {
   type,
   version: '1.0',
@@ -33,6 +37,7 @@ const manifest: ElementManifest = {
   ssr: false,
   initState,
   ui,
+  mocks,
 };
 
 export default manifest;

--- a/packages/manifest/src/interfaces.ts
+++ b/packages/manifest/src/interfaces.ts
@@ -35,4 +35,7 @@ export interface ElementManifest {
     icon: string;
     forceFullWidth: boolean;
   };
+  mocks?: {
+    displayContexts: Array<{ name: string; data: any }>;
+  };
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,6 +1,11 @@
 import type { HookServices, ServerRuntime } from '@tailor-cms/cek-common';
-import { initState, type } from 'tce-manifest';
+import { initState, mocks, type } from 'tce-manifest';
 import type { Element } from 'tce-manifest';
+
+// Detect if hooks are running in CEK (used for mocking end-system runtime)
+const IS_CEK = process.env.CEK_RUNTIME;
+// Don't use in production, use only when IS_CEK=true
+const USER_STATE: any = {};
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export function beforeSave(element: Element, services: HookServices) {
@@ -31,12 +36,38 @@ export function afterRetrieve(
   return element;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function beforeDisplay(element: Element, context: any) {
+  console.log('beforeDisplay hook');
+  console.log('beforeDisplay context', context);
+  return USER_STATE;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function onUserInteraction(
+  element: Element,
+  context: any,
+  payload: any,
+): any {
+  console.log('onUserInteraction', context, payload);
+  // Simulate user state update within CEK
+  if (IS_CEK) {
+    USER_STATE.interactionTimestamp = new Date().getTime();
+    Object.assign(USER_STATE, payload);
+  }
+  // Can have arbitrary return value (interpreted by target system)
+  // FE is updated if updateDisplayState is true
+  return { updateDisplayState: true };
+}
+
 export const hookMap = new Map(
   Object.entries({
     beforeSave,
     afterSave,
     afterLoaded,
     afterRetrieve,
+    onUserInteraction,
+    beforeDisplay,
   }),
 );
 
@@ -48,6 +79,9 @@ export default {
   afterSave,
   afterLoaded,
   afterRetrieve,
+  onUserInteraction,
+  beforeDisplay,
+  mocks,
 };
 
-export { type, initState };
+export { type, initState, mocks };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 0.0.2
         version: 0.0.2(@typescript-eslint/eslint-plugin@6.7.2)(@typescript-eslint/parser@6.7.2)(eslint-config-prettier@9.0.0)(eslint-config-semistandard@17.0.0)(eslint-config-standard@17.1.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.1.0)(eslint-plugin-prettier@5.0.0)(eslint-plugin-promise@6.1.1)(eslint-plugin-vue@9.17.0)(eslint-plugin-vuejs-accessibility@2.2.0)(eslint@8.49.0)
       '@tailor-cms/tce-boot':
-        specifier: 0.1.1
-        version: 0.1.1(@types/node@20.5.7)
+        specifier: 0.2.0-beta.7
+        version: 0.2.0-beta.7(@types/node@20.5.7)
       '@types/node':
         specifier: ^20.5.7
         version: 20.5.7
@@ -586,10 +586,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@tailor-cms/cek-common@0.0.1:
-    resolution: {integrity: sha512-Mi+V01JypQPJqdDKl0QrQYfEV92SNl+KIgtV/9VhGE8tYBItb4Fdhq6hXW2/3qwB7163raNLG6oZAUaDBVAQ2A==}
-    dev: true
-
   /@tailor-cms/cek-common@0.0.3:
     resolution: {integrity: sha512-QZGKfGb8sdmS/4U2ZdbG8VKD816Q2AoL4t23/WGXyo5wgpdjw4n9eNYNTwv8kp/pE02LzSBG+CUOMTb3UAqPoA==}
     dev: true
@@ -624,13 +620,13 @@ packages:
       eslint-plugin-vuejs-accessibility: 2.2.0(eslint@8.49.0)
     dev: true
 
-  /@tailor-cms/tce-boot@0.1.1(@types/node@20.5.7):
-    resolution: {integrity: sha512-CZYcslHGrlWvsx20uE9tWCnyeZH+mRGZ95283SaAXJFbfdLzIdj2ch1myAE2Egwtn52TcXaSS95Sj1RRV87UlQ==}
+  /@tailor-cms/tce-boot@0.2.0-beta.7(@types/node@20.5.7):
+    resolution: {integrity: sha512-2Y7DuUDUzFe/qmhUgsftrTA7ZlvEYB/PvqAMTKSUrz/bfqhOpgYAhxqq9IC56leWpMhdiUYY1Z/Mu9hbklsFCQ==}
     dependencies:
-      '@tailor-cms/tce-display-runtime': 0.1.0(@types/node@20.5.7)
-      '@tailor-cms/tce-edit-runtime': 0.1.0(@types/node@20.5.7)
-      '@tailor-cms/tce-preview-runtime': 0.1.0(@types/node@20.5.7)
-      '@tailor-cms/tce-server-runtime': 0.1.0(@types/node@20.5.7)
+      '@tailor-cms/tce-display-runtime': 0.2.0-beta.7(@types/node@20.5.7)
+      '@tailor-cms/tce-edit-runtime': 0.2.0-beta.7(@types/node@20.5.7)
+      '@tailor-cms/tce-preview-runtime': 0.2.0-beta.7(@types/node@20.5.7)
+      '@tailor-cms/tce-server-runtime': 0.2.0-beta.7(@types/node@20.5.7)
       boxen: 7.1.1
       concurrently: 8.2.1
       fkill: 8.1.1
@@ -666,8 +662,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-display-runtime@0.1.0(@types/node@20.5.7):
-    resolution: {integrity: sha512-mTtViqvzmVVwx5RATY1MVb+xpodp57R9EtBhSC5pyqRDD8GKV6CxPLCJVyQzaKlAG+bfUSYKrWYFvaWCO9lpPw==}
+  /@tailor-cms/tce-display-runtime@0.2.0-beta.7(@types/node@20.5.7):
+    resolution: {integrity: sha512-ws4T1MeTOeEhXnqGwroqUWTnbLB9Sdgp6tsYipZ9ipfDNzfGGoCuwzZL46o3gL8LegtybmVSlEv7nJvPL7r4aQ==}
     dependencies:
       '@mdi/font': 7.2.96
       '@vitejs/plugin-vue': 4.3.4(vite@4.4.9)(vue@3.3.4)
@@ -701,12 +697,12 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-edit-runtime@0.1.0(@types/node@20.5.7):
-    resolution: {integrity: sha512-+ZIin9EaPUCtoWzS36/hHiuACrWrULX+ZjdX98cMJT/BmV7FBIKBXeEdmWbeRWMBO2xfi4k9XLUYTlWKDn3oeA==}
+  /@tailor-cms/tce-edit-runtime@0.2.0-beta.7(@types/node@20.5.7):
+    resolution: {integrity: sha512-kyLfXeB3jAY0N/6rulJPQ1nkZJhLFVWVtIrbNMK74NMAK7jzvx9GFeMFmgjbOH7HqMOfDWV/sfkBPBSKaSr9FA==}
     dependencies:
       '@extensionengine/vue-radio': 1.0.0-beta.5
       '@mdi/font': 7.2.96
-      '@tailor-cms/cek-common': 0.0.1
+      '@tailor-cms/cek-common': 0.0.3
       '@vitejs/plugin-vue2': 2.2.0(vite@4.4.9)(vue@2.7.14)
       axios: 1.5.1
       ky: 1.0.1
@@ -733,8 +729,8 @@ packages:
       - terser
     dev: true
 
-  /@tailor-cms/tce-preview-runtime@0.1.0(@types/node@20.5.7):
-    resolution: {integrity: sha512-TPxs3GKzyZwsKhWYwjcvZq4X/zryaWGRcUExt/W7z3qYMjWD5P8eOOjY6ofyhnL7ePrdHxmeabK7Q/AgMoeG6w==}
+  /@tailor-cms/tce-preview-runtime@0.2.0-beta.7(@types/node@20.5.7):
+    resolution: {integrity: sha512-K4lRSE+WLCtdtPtI4ZGVJZKtRs8umdcEHxeGZnGE1LtN9N76wZBOop/FnDppCkR9A5ObZsetS1dkK3DXjeA7Cg==}
     dependencies:
       '@mdi/font': 7.2.96
       '@vitejs/plugin-vue': 4.3.4(vite@4.4.9)(vue@3.3.4)
@@ -762,8 +758,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-server-runtime@0.1.0(@types/node@20.5.7):
-    resolution: {integrity: sha512-oStQNDUQFxDlCSSJuXR5EAeiyhmQOO5tqFUxNFdSDVmeJkkBACJDM/Ctue1dI35Wgof/HE6tFmjJT5jpaWsyAA==}
+  /@tailor-cms/tce-server-runtime@0.2.0-beta.7(@types/node@20.5.7):
+    resolution: {integrity: sha512-6/AbTYeWoSoYK29RSKeJ6DFLAyZHZRRtJFFWosQyH3rUPg49w72TBe8vQJVHNj9dTOzTE1/5ApOPVFJYiuQW0A==}
     dependencies:
       bluebird: 3.7.2
       cors: 2.8.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: 0.0.2
         version: 0.0.2(@typescript-eslint/eslint-plugin@6.7.2)(@typescript-eslint/parser@6.7.2)(eslint-config-prettier@9.0.0)(eslint-config-semistandard@17.0.0)(eslint-config-standard@17.1.0)(eslint-plugin-import@2.28.1)(eslint-plugin-n@16.1.0)(eslint-plugin-prettier@5.0.0)(eslint-plugin-promise@6.1.1)(eslint-plugin-vue@9.17.0)(eslint-plugin-vuejs-accessibility@2.2.0)(eslint@8.49.0)
       '@tailor-cms/tce-boot':
-        specifier: 0.2.0-beta.7
-        version: 0.2.0-beta.7(@types/node@20.5.7)
+        specifier: 0.2.0
+        version: 0.2.0(@types/node@20.5.7)
       '@types/node':
         specifier: ^20.5.7
         version: 20.5.7
@@ -620,13 +620,13 @@ packages:
       eslint-plugin-vuejs-accessibility: 2.2.0(eslint@8.49.0)
     dev: true
 
-  /@tailor-cms/tce-boot@0.2.0-beta.7(@types/node@20.5.7):
-    resolution: {integrity: sha512-2Y7DuUDUzFe/qmhUgsftrTA7ZlvEYB/PvqAMTKSUrz/bfqhOpgYAhxqq9IC56leWpMhdiUYY1Z/Mu9hbklsFCQ==}
+  /@tailor-cms/tce-boot@0.2.0(@types/node@20.5.7):
+    resolution: {integrity: sha512-CkElLiqt+uOifQqSavYWLAHioD9wV44cju9JLK/koF/vMhdNUsTtZtiMiy+M9Qt9PqGY4e+Es263BMk3IG9z6Q==}
     dependencies:
-      '@tailor-cms/tce-display-runtime': 0.2.0-beta.7(@types/node@20.5.7)
-      '@tailor-cms/tce-edit-runtime': 0.2.0-beta.7(@types/node@20.5.7)
-      '@tailor-cms/tce-preview-runtime': 0.2.0-beta.7(@types/node@20.5.7)
-      '@tailor-cms/tce-server-runtime': 0.2.0-beta.7(@types/node@20.5.7)
+      '@tailor-cms/tce-display-runtime': 0.2.0(@types/node@20.5.7)
+      '@tailor-cms/tce-edit-runtime': 0.2.0(@types/node@20.5.7)
+      '@tailor-cms/tce-preview-runtime': 0.2.0(@types/node@20.5.7)
+      '@tailor-cms/tce-server-runtime': 0.2.0(@types/node@20.5.7)
       boxen: 7.1.1
       concurrently: 8.2.1
       fkill: 8.1.1
@@ -662,8 +662,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-display-runtime@0.2.0-beta.7(@types/node@20.5.7):
-    resolution: {integrity: sha512-ws4T1MeTOeEhXnqGwroqUWTnbLB9Sdgp6tsYipZ9ipfDNzfGGoCuwzZL46o3gL8LegtybmVSlEv7nJvPL7r4aQ==}
+  /@tailor-cms/tce-display-runtime@0.2.0(@types/node@20.5.7):
+    resolution: {integrity: sha512-Rtpx0g08Z8ggx/0h/1MqGm/sequejubCHcvL4NGJ+sfZKZSc8rMLpNYcVJ/r1fHjx4FDDZzUj9D4BIr8CwDJhg==}
     dependencies:
       '@mdi/font': 7.2.96
       '@vitejs/plugin-vue': 4.3.4(vite@4.4.9)(vue@3.3.4)
@@ -697,8 +697,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-edit-runtime@0.2.0-beta.7(@types/node@20.5.7):
-    resolution: {integrity: sha512-kyLfXeB3jAY0N/6rulJPQ1nkZJhLFVWVtIrbNMK74NMAK7jzvx9GFeMFmgjbOH7HqMOfDWV/sfkBPBSKaSr9FA==}
+  /@tailor-cms/tce-edit-runtime@0.2.0(@types/node@20.5.7):
+    resolution: {integrity: sha512-/wBv6HSMUTZKMPXBQdqkjdsdWE+gs1Ng/Rg18aQR35cBeZ0cMm6KeU13x3hjKW09KlbT6Hk+Gi6LJe97kuXRlQ==}
     dependencies:
       '@extensionengine/vue-radio': 1.0.0-beta.5
       '@mdi/font': 7.2.96
@@ -729,8 +729,8 @@ packages:
       - terser
     dev: true
 
-  /@tailor-cms/tce-preview-runtime@0.2.0-beta.7(@types/node@20.5.7):
-    resolution: {integrity: sha512-K4lRSE+WLCtdtPtI4ZGVJZKtRs8umdcEHxeGZnGE1LtN9N76wZBOop/FnDppCkR9A5ObZsetS1dkK3DXjeA7Cg==}
+  /@tailor-cms/tce-preview-runtime@0.2.0(@types/node@20.5.7):
+    resolution: {integrity: sha512-xuY9qKkRkF46/ll1l5M4iq6b7bPgIJsb7UokroDX2ODAhTcTgiqYYjZaZ10gk53TOBZmFHCPK4cvdy6+aokn/Q==}
     dependencies:
       '@mdi/font': 7.2.96
       '@vitejs/plugin-vue': 4.3.4(vite@4.4.9)(vue@3.3.4)
@@ -758,8 +758,8 @@ packages:
       - webpack-plugin-vuetify
     dev: true
 
-  /@tailor-cms/tce-server-runtime@0.2.0-beta.7(@types/node@20.5.7):
-    resolution: {integrity: sha512-6/AbTYeWoSoYK29RSKeJ6DFLAyZHZRRtJFFWosQyH3rUPg49w72TBe8vQJVHNj9dTOzTE1/5ApOPVFJYiuQW0A==}
+  /@tailor-cms/tce-server-runtime@0.2.0(@types/node@20.5.7):
+    resolution: {integrity: sha512-wh9p3qHF/RfaqKuNqPDCE5L80dkreZscqNYwYcDa7967hq65o0gPYLAndG6mi1by17g5ZXU91tyx3No+H444Dw==}
     dependencies:
       bluebird: 3.7.2
       cors: 2.8.5


### PR DESCRIPTION
Closes #9 , #14

#### Changes
- [Enabled user-state hooks](https://tailor-cms.github.io/xt/server-package.html#user-state-hooks)

#### Migration instructions
- Bump tce-boot to `0.2.0`
- [Add the display context to the manifest interface](https://github.com/tailor-cms/tce-template/pull/16/files#diff-363caee1e8047788dee5a0a3feca5d40a88c160dd36abadb550e8577ae0d3244R38)
- [Add the example display context to the manifest](https://github.com/tailor-cms/tce-template/pull/16/files#diff-c248ce0c077134efe1982e29743139541a2d28d6ace0e3f6e5a50cf09f1beaafR29).
- [Add beforeDisplay and onUserInteraction hooks](https://github.com/tailor-cms/tce-template/pull/16/files#diff-8e6dfbbfb522575fe7c568c2de518bf9de351de83c9dbb48eaa865cd54450eb3R40)
- [Define userState prop on Display component](https://github.com/tailor-cms/tce-template/pull/16/files#diff-cfb5d05096f2f57087b355fa04ea9ac63033d96b4f1100db0991c69baa4aebc7R12) 